### PR TITLE
 Fix TypeError unorderable types float() < NoneType()

### DIFF
--- a/jsondiff/__init__.py
+++ b/jsondiff/__init__.py
@@ -431,7 +431,8 @@ class JsonDiffer(object):
                 for x in removed
                 for y in added
             ),
-            reverse=True
+            reverse=True,
+            key=lambda x: x[0]
         )
         r2 = set(removed)
         a2 = set(added)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,7 +2,7 @@ import unittest
 
 from jsondiff import diff, replace, add, discard, insert, delete, update, JsonDiffer
 
-from utils import generate_random_json, perturbate_json
+from .utils import generate_random_json, perturbate_json
 
 from nose_random import randomize
 


### PR DESCRIPTION
Reproducible under py3.5. Didn't check other versions.