### PR TITLE
Fixed unmarshal()

### DIFF
--- a/jsondiff/__init__.py
+++ b/jsondiff/__init__.py
@@ -363,7 +363,7 @@ class JsonDiffer(object):
         self.options.loader = loader
         self.options.dumper = dumper
         self._symbol_map = {
-            symbol.label: symbol
+            '$' + symbol.label: symbol
             for symbol in (add, discard, insert, delete, update)
         }
 


### PR DESCRIPTION
Before making this change, I have to call `unmarshal()` twice to reverse the `marshal()` operation for a diff object. For instance, in this code:

```
import json
import jsondiff

def dump_diff(j_diff):
    j = jsondiff.JsonDiffer()
    return json.dumps(j.marshal(j_diff))

def load_diff(j_diff_str):
    j = jsondiff.JsonDiffer()
    # Have to call unmarshal 2x - (1) '$delete' -> 'delete' (2) 'delete' -> delete
    return j.unmarshal(j.unmarshal(json.loads(j_diff_str)))

if __name__ == '__main__':
    a = {'a':1,'b':{'c':2,'d':3}}
    b = {'a':10,'b':{'c':20}}
    a_b = jsondiff.diff(a,b)

    d = dump_diff(a_b)
    print('DUMP: {}'.format(d))

    l = load_diff(d)
    print('LOAD: {}'.format(l))

    patched = jsondiff.patch(a, l)
    print('PATCHED:  {}'.format(patched))
    print('EXPECTED: {}'.format(b))
```

With this change, it only takes 1 call to `unmarshal` instead of 2.

But perhaps I am missing something?