### PR TITLE
Exlude 'tests' directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.dirname(__file__), 'jsondiff', '__init__.py')) as
 
 setup(
     name='jsondiff',
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests']),
     version=version,
     description='Diff JSON and JSON-like structures in Python',
     author='Zoomer Analytics LLC',


### PR DESCRIPTION
This excludes 'tests' directory which if included, brings in
dependency on nose_random which is not desirable.